### PR TITLE
Fixed timestep

### DIFF
--- a/Editor/Editor.cs
+++ b/Editor/Editor.cs
@@ -28,11 +28,7 @@ partial class Editor : IGame {
 	}
 
 	public void Tick() {
-		TimeSince poop = 0f;
-
-		if ( poop > 1f ) {
-
-		}
+		Console.WriteLine( "Upate" );
 	}
 
 	//readonly Model _prospectIcon = Model.Load( "C:/Users/ian/Documents/Models/sword/longsword.mdl" );

--- a/Editor/Editor.cs
+++ b/Editor/Editor.cs
@@ -20,6 +20,10 @@ partial class Editor : IGame {
 
 	static void Main() => Entry.Run<Editor>();
 
+	public GameOptions Options => GameOptions.Default with {
+		TickRate = 60
+	};
+
 	public void Start() {
 		Window.Title = "Prospect Editor";
 
@@ -27,9 +31,7 @@ partial class Editor : IGame {
 		_projectManager.TryRestoreProject( _settings.LastProjectPath );
 	}
 
-	public void Tick() {
-		Console.WriteLine( "Upate" );
-	}
+	public void Tick() { }
 
 	//readonly Model _prospectIcon = Model.Load( "C:/Users/ian/Documents/Models/sword/longsword.mdl" );
 	float _speen = 0f;

--- a/Editor/Editor.cs
+++ b/Editor/Editor.cs
@@ -28,7 +28,11 @@ partial class Editor : IGame {
 	}
 
 	public void Tick() {
+		TimeSince poop = 0f;
 
+		if ( poop > 1f ) {
+
+		}
 	}
 
 	//readonly Model _prospectIcon = Model.Load( "C:/Users/ian/Documents/Models/sword/longsword.mdl" );

--- a/Editor/ProjectManager.SampleFiles.cs
+++ b/Editor/ProjectManager.SampleFiles.cs
@@ -7,6 +7,8 @@ partial class ProjectManager {
 namespace YourGame;
 
 public class Game : IGame {
+	public GameOptions Options => GameOptions.Default;
+
 	public void Start() { }
 	public void Shutdown() { }
 

--- a/Engine/Entry.cs
+++ b/Engine/Entry.cs
@@ -10,8 +10,8 @@ using ImGuiNET;
 namespace Prospect.Engine;
 
 public static partial class Entry {
-	public const uint TICK_RATE = 2;
-	public const float TICK_DELTA = 1f / (float)TICK_RATE;
+	public static uint TickRate = 0;
+	public static float TickDelta = 0f;
 
 	internal static IGraphicsBackend Graphics { get; private set; }
 	static IGame? _game;
@@ -39,6 +39,8 @@ public static partial class Entry {
 	}
 
 	static void runGame( IGame game ) {
+		applyOptions( game );
+
 		RawGameTime.Start();
 
 		_game = game;
@@ -47,6 +49,11 @@ public static partial class Entry {
 		Graphics.RunLoop();
 
 		shutdown();
+	}
+
+	static void applyOptions( IGame game ) {
+		TickRate = game.Options.TickRate;
+		TickDelta = 1f / (float)TickRate;
 	}
 
 	static void onGraphicsLoaded() {

--- a/Engine/Entry.cs
+++ b/Engine/Entry.cs
@@ -10,8 +10,14 @@ using ImGuiNET;
 namespace Prospect.Engine;
 
 public static partial class Entry {
+	public const uint TICK_RATE = 2;
+	public const float TICK_DELTA = 1f / (float)TICK_RATE;
+
 	internal static IGraphicsBackend Graphics { get; private set; }
 	static IGame? _game;
+
+	internal static Stopwatch RawGameTime { get; private set; } = new();
+	internal static uint CurrentTick { get; private set; } = 0;
 
 	static Entry() {
 		Graphics = new OpenGL.GraphicsBackend {
@@ -33,6 +39,8 @@ public static partial class Entry {
 	}
 
 	static void runGame( IGame game ) {
+		RawGameTime.Start();
+
 		_game = game;
 		game.Start();
 
@@ -47,7 +55,12 @@ public static partial class Entry {
 	}
 
 	static void update( float delta ) {
-		_game?.Tick();
+		var expectedCurrentTick = Time.CalculateCurrentTick();
+
+		while ( CurrentTick < expectedCurrentTick ) {
+			CurrentTick++;
+			_game?.Tick();
+		}
 	}
 
 	static void render() {

--- a/Engine/GameOptions.cs
+++ b/Engine/GameOptions.cs
@@ -1,0 +1,9 @@
+﻿namespace Prospect.Engine;
+
+public struct GameOptions {
+	public readonly static GameOptions Default = new();
+
+	public uint TickRate = 60;
+
+	public GameOptions() { }
+}

--- a/Engine/Graphics/OpenGl/Window.cs
+++ b/Engine/Graphics/OpenGl/Window.cs
@@ -32,7 +32,6 @@ class Window : IWindow, IDisposable {
 
 	public Window() {
 		WindowOptions options = WindowOptions.Default with {
-			UpdatesPerSecond = 165,
 			FramesPerSecond = 165,
 			VSync = false,
 

--- a/Engine/IGame.cs
+++ b/Engine/IGame.cs
@@ -1,6 +1,8 @@
 namespace Prospect.Engine;
 
 public interface IGame {
+	GameOptions Options { get; }
+
 	void Start() { }
 	void Shutdown() { }
 

--- a/Engine/Time/Time.cs
+++ b/Engine/Time/Time.cs
@@ -1,8 +1,8 @@
 ﻿namespace Prospect.Engine;
 
 public static class Time {
-	public static uint TickRate => Entry.TICK_RATE;
-	public static float Delta => Entry.TICK_DELTA;
+	public static uint TickRate => Entry.TickRate;
+	public static float Delta => Entry.TickDelta;
 
 	/// <summary> Time since the game's startup </summary>
 	public static TimeSince SinceStarted => CalculateTimeFromTick( Tick );

--- a/Engine/Time/Time.cs
+++ b/Engine/Time/Time.cs
@@ -1,6 +1,13 @@
 ﻿namespace Prospect.Engine;
 
 public static class Time {
+	public static uint TickRate => Entry.TICK_RATE;
+	public static float Delta => Entry.TICK_DELTA;
+
 	/// <summary> Time since the game's startup </summary>
-	public static TimeSince SinceStarted => 0f;
+	public static TimeSince SinceStarted => CalculateTimeFromTick( Tick );
+	public static uint Tick => Entry.CurrentTick;
+
+	internal static uint CalculateCurrentTick() => (uint)MathF.Ceiling( (float)Entry.RawGameTime.Elapsed.TotalSeconds * (float)TickRate );
+	internal static float CalculateTimeFromTick( uint tick ) => (float)tick / (float)TickRate;
 }

--- a/Engine/Time/Time.cs
+++ b/Engine/Time/Time.cs
@@ -1,0 +1,6 @@
+﻿namespace Prospect.Engine;
+
+public static class Time {
+	/// <summary> Time since the game's startup </summary>
+	public static TimeSince SinceStarted => 0f;
+}

--- a/Engine/Time/TimeSince.cs
+++ b/Engine/Time/TimeSince.cs
@@ -1,0 +1,17 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Prospect.Engine;
+
+public struct TimeSince : IEquatable<TimeSince> {
+	public float StartTime;
+
+	public static bool operator ==( TimeSince t1, TimeSince t2 ) => t1.StartTime == t2.StartTime;
+	public static bool operator !=( TimeSince t1, TimeSince t2 ) => t1.StartTime != t2.StartTime;
+
+	public bool Equals( TimeSince other ) => this == other;
+	public override bool Equals( [NotNullWhen( true )] object? obj ) => obj is TimeSince other && this == other;
+	public override int GetHashCode() => HashCode.Combine( StartTime );
+
+	public static implicit operator TimeSince( float time ) => new() { StartTime = time };
+	public static implicit operator float( TimeSince t ) => Time.SinceStarted - t.StartTime;
+}

--- a/Engine/Time/TimeUntil.cs
+++ b/Engine/Time/TimeUntil.cs
@@ -1,0 +1,17 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Prospect.Engine;
+
+public struct TimeUntil : IEquatable<TimeUntil> {
+	public float GoalTime;
+
+	public static bool operator ==( TimeUntil t1, TimeUntil t2 ) => t1.GoalTime == t2.GoalTime;
+	public static bool operator !=( TimeUntil t1, TimeUntil t2 ) => t1.GoalTime != t2.GoalTime;
+
+	public bool Equals( TimeUntil other ) => this == other;
+	public override bool Equals( [NotNullWhen( true )] object? obj ) => obj is TimeUntil other && this == other;
+	public override int GetHashCode() => HashCode.Combine( GoalTime );
+
+	public static implicit operator TimeUntil( float time ) => new() { GoalTime = time };
+	public static implicit operator float( TimeUntil t ) => t.GoalTime - Time.SinceStarted;
+}


### PR DESCRIPTION
Timestep is now fixed, added `TimeSince` and `TimeUntil` structs (same as S&box), added `Time` that lets you see the current time, tick, etc.

Added a `GameOptions` struct which is read when starting the game, currently `TickRate` is specified there but its expandable for more stuff later on.