### PR TITLE
Results

### DIFF
--- a/Editor/Editor.cs
+++ b/Editor/Editor.cs
@@ -3,7 +3,6 @@ global using System.Linq;
 global using System.Collections.Generic;
 
 using Prospect.Engine;
-using Microsoft.CodeAnalysis;
 using System.IO;
 
 namespace Prospect.Editor;
@@ -24,7 +23,7 @@ partial class Editor : IGame {
 		Window.OnFileDrop = onFileDrop;
 
 		_settings = Resources.GetOrCreate<EditorSettings>( "settings.eds" );
-		_projectManager.TryOpenProject( Path.Combine( _settings.LastProjectPath, "project.proj" ) );
+		_projectManager.OpenProject( Path.Combine( _settings.LastProjectPath, "project.proj" ) );
 	}
 
 	public void Tick() { }
@@ -43,8 +42,8 @@ partial class Editor : IGame {
 		Console.WriteLine( "noitdon" );
 
 		foreach ( var path in paths ) {
-			_projectManager.TryOpenProject( path );
-			_projectManager.TryCreateProject( path );
+			_projectManager.OpenProject( path );
+			_projectManager.CreateProject( path );
 		}
 	}
 }

--- a/Engine/Result.cs
+++ b/Engine/Result.cs
@@ -1,9 +1,21 @@
 namespace Prospect.Engine;
 
-public readonly struct Result<TValue> {
-	public static Result<TValue> Ok( TValue value ) => new( true, value );
-	public static Result<TValue> Fail() => new( false );
+public readonly struct Result {
+    // All the constructors are here to make the API nice
+	public static Result Ok() => new( true);
+	public static Result Fail() => new( false );
+    public static Result<TV> Ok<TV>( TV value ) => new( true, value );
+	public static Result<TV> Fail<TV>() => new( false );
+    public static Result<TV, TE> Ok<TV, TE>( TV value ) => new( true, value );
+	public static Result<TV, TE> Fail<TV, TE>( TE error ) => new( false, error: error );
 
+	public readonly bool IsOk;
+	public bool Failed => !IsOk;
+
+	Result( bool isOk ) => IsOk = isOk;
+}
+
+public readonly struct Result<TValue> {
 	public readonly bool IsOk;
 	public bool Failed => !IsOk;
 
@@ -12,7 +24,7 @@ public readonly struct Result<TValue> {
 	readonly TValue _value;
 
 #nullable disable
-	Result( bool isOk, TValue value = default ) {
+	internal Result( bool isOk, TValue value = default ) {
 #nullable enable
 		IsOk = isOk;
 		_value = value;
@@ -20,9 +32,6 @@ public readonly struct Result<TValue> {
 }
 
 public readonly struct Result<TValue, TError> {
-	public static Result<TValue, TError> Ok( TValue value ) => new( true, value );
-	public static Result<TValue, TError> Fail( TError error ) => new( false, error: error );
-
 	public readonly bool IsOk;
 	public bool Failed => !IsOk;
 
@@ -33,7 +42,7 @@ public readonly struct Result<TValue, TError> {
 	readonly TError _error;
 
 #nullable disable
-	Result( bool isOk, TValue value = default, TError error = default ) {
+	internal Result( bool isOk, TValue value = default, TError error = default ) {
 #nullable enable
 		IsOk = isOk;
 		_value = value;

--- a/Engine/Result.cs
+++ b/Engine/Result.cs
@@ -1,0 +1,42 @@
+namespace Prospect.Engine;
+
+public readonly struct Result<TValue> {
+	public static Result<TValue> Ok( TValue value ) => new( true, value );
+	public static Result<TValue> Fail() => new( false );
+
+	public readonly bool IsOk;
+	public bool Failed => !IsOk;
+
+	public TValue Value => IsOk ? _value : throw new Exception( "Tried accessing Result.Value, but Result is Error" );
+
+	readonly TValue _value;
+
+#nullable disable
+	Result( bool isOk, TValue value = default ) {
+#nullable enable
+		IsOk = isOk;
+		_value = value;
+	}
+}
+
+public readonly struct Result<TValue, TError> {
+	public static Result<TValue, TError> Ok( TValue value ) => new( true, value );
+	public static Result<TValue, TError> Fail( TError error ) => new( false, error: error );
+
+	public readonly bool IsOk;
+	public bool Failed => !IsOk;
+
+	public TValue Value => IsOk ? _value : throw new Exception( "Tried accessing Result.Value, but Result is Error" );
+	public TError Error => Failed ? _error : throw new Exception( "Tried accessing Result.Error, but Result is Ok" );
+
+	readonly TValue _value;
+	readonly TError _error;
+
+#nullable disable
+	Result( bool isOk, TValue value = default, TError error = default ) {
+#nullable enable
+		IsOk = isOk;
+		_value = value;
+		_error = error;
+	}
+}


### PR DESCRIPTION
I think the result pattern is much nicer than exceptions and this PR implements that pattern.
Return `Result` from methods which can fail. There are also `Result<TValue>` and `Result<TValue, TError` structs for when you need the result to be more descriptive

Currently `Prospect.Editor` was updated to accommodate for this change