### PR TITLE
Texture resources

### DIFF
--- a/assets/fish.mdl
+++ b/assets/fish.mdl
@@ -1,2 +1,2 @@
 MeshPath: fish.glb
-TexturePath: fish.png
+TexturePath: fish.tex

--- a/assets/fish.tex
+++ b/assets/fish.tex
@@ -1,0 +1,2 @@
+ImagePath: fish.png
+Filter: Nearest

--- a/src/Prospect.Engine/Entry.cs
+++ b/src/Prospect.Engine/Entry.cs
@@ -84,7 +84,11 @@ public static partial class Entry {
         foreach ( var model in Model._cache.Values.Where( m => !m._hasLoaded ) )
             model.postBackendLoad();
 
-		_ = startGame();
+        // And textures
+        foreach ( var texture in Texture._cache.Values.Where( m => !m._hasLoaded ) )
+            texture.postBackendLoad();
+
+        _ = startGame();
 	}
 
 	static void onUpdate() {

--- a/src/Prospect.Engine/Graphics/IGraphicsBackend.cs
+++ b/src/Prospect.Engine/Graphics/IGraphicsBackend.cs
@@ -28,8 +28,8 @@ interface IGraphicsBackend {
 	void RunLoop();
 
 	// Rendering
-	Result<IModel> LoadModel( string path, ITexture texture );
-	Result<ITexture> LoadTexture( string path );
+	Result<IModel> LoadModel( string path );
+	Result<ITexture> LoadTexture( string path, TextureFilter filter );
 
 	PolygonMode PolygonMode { get; set; }
 

--- a/src/Prospect.Engine/Graphics/Model.cs
+++ b/src/Prospect.Engine/Graphics/Model.cs
@@ -5,55 +5,63 @@ using System.IO;
 
 namespace Prospect.Engine;
 
-public sealed class Model {
-	internal readonly static Dictionary<string, Model> _cache = new();
+public sealed class Model
+{
+    internal readonly static Dictionary<string, Model> _cache = new();
 
-	internal IModel BackendModel { get; private set; } = null!;
-	internal ITexture BackendTexture { get; private set; } = null!;
+    internal IModel BackendModel { get; private set; } = null!;
+    internal Texture Texture { get; private set; }
 
     internal bool _hasLoaded = false;
-	readonly ModelResource _preset;
+    readonly ModelResource _preset;
 
-	// Mark the constructor as private, prevent instantiation!
-	Model( ModelResource preset ) => _preset = preset;
+    // Mark the constructor as private, prevent instantiation!
+    Model( ModelResource preset, Texture texture )
+    {
+        _preset = preset;
+        Texture = texture;
+    }
 
-	public static Model Load( string path ) {
-		if ( _cache.TryGetValue( path, out var mdl ) )
-			return mdl;
+    public static Model Load( string path )
+    {
+        if ( _cache.TryGetValue( path, out var mdl ) )
+            return mdl;
 
-		if ( Resources.Get<ModelResource>( path ) is not ModelResource res )
-			// TODO: Make an in-engine error model and return that instead of throwing
-			throw new Exception( "Model ain't there pal" );
+        if ( Resources.Get<ModelResource>( path ) is not ModelResource res )
+            // TODO: Make an in-engine error model and return that instead of throwing
+            throw new Exception( "Model ain't there pal" );
 
-		Model model = new( res );
+        var texturePath = Path.Combine( res.Directory, res.TexturePath );
+        var texture = Texture.Load( texturePath );
 
-		if ( Entry.Graphics.HasLoaded )
+        Model model = new( res, texture );
+
+        if ( Entry.Graphics.HasLoaded )
         {
-			model.updateFromResource( res );
+            model.updateFromResource( res );
             model._hasLoaded = true;
         }
 
-		_cache[path] = model;
-		return model;
-	}
+        _cache[ path ] = model;
+        return model;
+    }
 
-	void updateFromResource( ModelResource res ) {
+    void updateFromResource( ModelResource res )
+    {
         // These are relative
-        var texturePath = Path.Combine( res.Directory, res.TexturePath );
         var meshPath = Path.Combine( res.Directory, res.MeshPath );
 
         // TODO: Use placeholder error resources if these fail
-        var texture = Entry.Graphics.LoadTexture( texturePath );
-		var backendMesh = Entry.Graphics.LoadModel( meshPath, texture.Value );
+        var backendMesh = Entry.Graphics.LoadModel( meshPath );
 
-		BackendModel = backendMesh.Value;
-		BackendTexture = texture.Value;
-	}
+        BackendModel = backendMesh.Value;
+    }
 
-	internal void postBackendLoad() {
-		if ( _hasLoaded ) return;
-		_hasLoaded = true;
+    internal void postBackendLoad()
+    {
+        if ( _hasLoaded ) return;
+        _hasLoaded = true;
 
         updateFromResource( _preset );
-	}
+    }
 }

--- a/src/Prospect.Engine/Graphics/Model.cs
+++ b/src/Prospect.Engine/Graphics/Model.cs
@@ -28,7 +28,10 @@ public sealed class Model {
 		Model model = new( res );
 
 		if ( Entry.Graphics.HasLoaded )
+        {
 			model.updateFromResource( res );
+            model._hasLoaded = true;
+        }
 
 		_cache[path] = model;
 		return model;
@@ -50,8 +53,6 @@ public sealed class Model {
 	internal void postBackendLoad() {
 		if ( _hasLoaded ) return;
 		_hasLoaded = true;
-
-		Console.WriteLine( "amaload" );
 
         updateFromResource( _preset );
 	}

--- a/src/Prospect.Engine/Graphics/OpenGL/GraphicsBackend.Rendering.cs
+++ b/src/Prospect.Engine/Graphics/OpenGL/GraphicsBackend.Rendering.cs
@@ -70,9 +70,9 @@ partial class GraphicsBackend
         return model.Value;
     }
 
-    public Result<ITexture> LoadTexture( string path )
+    public Result<ITexture> LoadTexture( string path, TextureFilter filter )
     {
-        var texture = Texture.Load( _gl, path );
+        var texture = Texture.Load( _gl, path, filter );
         if ( texture.IsError ) return Result.Fail();
 
         return texture.Value;

--- a/src/Prospect.Engine/Graphics/OpenGL/GraphicsBackend.Rendering.cs
+++ b/src/Prospect.Engine/Graphics/OpenGL/GraphicsBackend.Rendering.cs
@@ -5,88 +5,98 @@ using Matrix4x4 = System.Numerics.Matrix4x4;
 
 namespace Prospect.Engine.OpenGL;
 
-partial class GraphicsBackend {
-	public PolygonMode PolygonMode {
-		get => _polygonMode;
-		set {
-			_polygonMode = value;
+partial class GraphicsBackend
+{
+    public PolygonMode PolygonMode
+    {
+        get => _polygonMode;
+        set
+        {
+            _polygonMode = value;
 
-			switch ( _polygonMode ) {
-				case PolygonMode.Normal:
-					_gl.PolygonMode( GLEnum.FrontAndBack, GLEnum.Fill );
-					break;
-				case PolygonMode.Wireframe:
-					_gl.PolygonMode( GLEnum.FrontAndBack, GLEnum.Line );
-					break;
-			}
-		}
-	}
+            switch ( _polygonMode )
+            {
+                case PolygonMode.Normal:
+                    _gl.PolygonMode( GLEnum.FrontAndBack, GLEnum.Fill );
+                    break;
+                case PolygonMode.Wireframe:
+                    _gl.PolygonMode( GLEnum.FrontAndBack, GLEnum.Line );
+                    break;
+            }
+        }
+    }
 
-	public Action OnLoad { private get; set; } = () => { };
-	public Action OnUpdate { private get; set; } = () => { };
-	public Action<float> OnRender { private get; set; } = ( f ) => { };
+    public Action OnLoad { private get; set; } = () => { };
+    public Action OnUpdate { private get; set; } = () => { };
+    public Action<float> OnRender { private get; set; } = ( f ) => { };
 
-	PolygonMode _polygonMode;
+    PolygonMode _polygonMode;
 
-	void initRendering() {
-		_mainModelShader = new Shader( _gl, Shaders.VERTEX_SOURCE, Shaders.FRAGMENT_SOURCE );
+    void initRendering()
+    {
+        _mainModelShader = new Shader( _gl, Shaders.VERTEX_SOURCE, Shaders.FRAGMENT_SOURCE );
 
-		// Better blending of texture edges or some shit
-		_gl.Enable( EnableCap.Blend );
-		_gl.BlendFunc( BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha );
+        // Better blending of texture edges or some shit
+        _gl.Enable( EnableCap.Blend );
+        _gl.BlendFunc( BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha );
 
-		_gl.Enable( EnableCap.DepthTest );
-		_gl.Enable( EnableCap.CullFace );
-	}
+        _gl.Enable( EnableCap.DepthTest );
+        _gl.Enable( EnableCap.CullFace );
+    }
 
-	Matrix4x4 _currentProjection;
-	void beginRender( float delta ) {
-		// Calculate camera projection that will be used for this frame
-		Point2 windowSize = new( _window.Size.X, _window.Size.Y );
-		_currentProjection = Matrix4x4.CreatePerspectiveFieldOfView( Camera.FieldOfView.ToRadians(), windowSize.Aspect, Camera.Near, Camera.Far );
+    Matrix4x4 _currentProjection;
+    void beginRender( float delta )
+    {
+        // Calculate camera projection that will be used for this frame
+        Point2 windowSize = new( _window.Size.X, _window.Size.Y );
+        _currentProjection = Matrix4x4.CreatePerspectiveFieldOfView( Camera.FieldOfView.ToRadians(), windowSize.Aspect, Camera.Near, Camera.Far );
 
-		_gl.ClearColor( Color.FromArgb( 255, 0, 0, 0 ) );
-		_gl.Clear( ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit );
+        _gl.ClearColor( Color.FromArgb( 255, 0, 0, 0 ) );
+        _gl.Clear( ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit );
 
-		_imGuiController?.Update( delta );
-	}
+        _imGuiController?.Update( delta );
+    }
 
-	void endRender() {
-		_imGuiController?.Render();
-	}
+    void endRender()
+    {
+        _imGuiController?.Render();
+    }
 
-	public Result<IModel> LoadModel( string path, ITexture texture ) {
-		if ( texture is not Texture tex ) return Result.Fail();
+    public Result<IModel> LoadModel( string path )
+    {
+        var model = Model.Load( _gl, path );
+        if ( model.IsError ) return Result.Fail();
 
-		var model = Model.Load( _gl, path, tex );
-		if ( model.IsError ) return Result.Fail();
+        return model.Value;
+    }
 
-		return model.Value;
-	}
+    public Result<ITexture> LoadTexture( string path )
+    {
+        var texture = Texture.Load( _gl, path );
+        if ( texture.IsError ) return Result.Fail();
 
-	public Result<ITexture> LoadTexture( string path ) {
-		var texture = Texture.Load( _gl, path );
-		if ( texture.IsError ) return Result.Fail();
+        return texture.Value;
+    }
 
-		return texture.Value;
-	}
+    public void DrawModel( Engine.Model model, Transform transform )
+    {
+        // BackendModel is never null, and its always from our backend
+        var backendModel = ( model.BackendModel as Model )!;
 
-	public void DrawModel( Engine.Model model, Transform transform ) {
-		// BackendModel is never null, and its always from our backend
-		var backendModel = (model.BackendModel as Model)!;
+        _mainModelShader.Use();
+        _mainModelShader.SetUniform( "uTexture", 0 );
+        _mainModelShader.SetUniform( "uTransform", transform.Matrix );
+        _mainModelShader.SetUniform( "uView", Camera.ViewMatrix );
+        _mainModelShader.SetUniform( "uProjection", _currentProjection );
 
-		_mainModelShader.Use();
-		_mainModelShader.SetUniform( "uTexture", 0 );
-		_mainModelShader.SetUniform( "uTransform", transform.Matrix );
-		_mainModelShader.SetUniform( "uView", Camera.ViewMatrix );
-		_mainModelShader.SetUniform( "uProjection", _currentProjection );
+        foreach ( var mesh in backendModel.Meshes )
+        {
+            mesh.Bind();
 
-		foreach ( var mesh in backendModel.Meshes ) {
-			mesh.Bind();
-
-			unsafe {
-				_gl.DrawElements( PrimitiveType.Triangles, mesh.IndiceCount, DrawElementsType.UnsignedInt, null );
-			}
-		}
-	}
+            unsafe
+            {
+                _gl.DrawElements( PrimitiveType.Triangles, mesh.IndiceCount, DrawElementsType.UnsignedInt, null );
+            }
+        }
+    }
 }

--- a/src/Prospect.Engine/Graphics/OpenGL/GraphicsBackend.Rendering.cs
+++ b/src/Prospect.Engine/Graphics/OpenGL/GraphicsBackend.Rendering.cs
@@ -82,6 +82,9 @@ partial class GraphicsBackend
     {
         // BackendModel is never null, and its always from our backend
         var backendModel = ( model.BackendModel as Model )!;
+        var backendTexture = ( model.Texture.BackendTexture as Texture )!;
+
+        backendTexture.Bind();
 
         _mainModelShader.Use();
         _mainModelShader.SetUniform( "uTexture", 0 );

--- a/src/Prospect.Engine/Graphics/OpenGL/Mesh.cs
+++ b/src/Prospect.Engine/Graphics/OpenGL/Mesh.cs
@@ -10,13 +10,10 @@ class Mesh : IDisposable {
 	readonly BufferObject<float> _vbo;
 	readonly BufferObject<uint> _ebo;
 	readonly VertexArrayObject<float, uint> _vao;
-	readonly Texture _texture;
 
-	public Mesh( GL gl, float[] vertices, uint[] indices, Texture texture ) {
+	public Mesh( GL gl, float[] vertices, uint[] indices ) {
 		VertexCount = (uint)vertices.Length;
 		IndiceCount = (uint)indices.Length;
-
-		_texture = texture;
 
 		_vbo = new( gl, BufferTargetARB.ArrayBuffer, vertices );
 		_ebo = new( gl, BufferTargetARB.ElementArrayBuffer, indices );
@@ -28,7 +25,6 @@ class Mesh : IDisposable {
 
 	public void Bind() {
 		_vao.Bind();
-		_texture.Bind( TextureUnit.Texture0 );
 	}
 
 	public void Dispose() {

--- a/src/Prospect.Engine/Graphics/OpenGL/Model.cs
+++ b/src/Prospect.Engine/Graphics/OpenGL/Model.cs
@@ -7,14 +7,14 @@ using AssMesh = Silk.NET.Assimp.Mesh;
 namespace Prospect.Engine.OpenGL;
 
 class Model : IModel, IDisposable {
-	public unsafe static Result<Model, string> Load( GL gl, string path, Texture texture ) {
+	public unsafe static Result<Model, string> Load( GL gl, string path ) {
 		var assimp = Assimp.GetApi();
 
 		var scene = assimp.ImportFile( path, (uint)PostProcessSteps.Triangulate );
 		if ( scene == null || scene->MFlags == Assimp.SceneFlagsIncomplete || scene->MRootNode == null )
 			return assimp.GetErrorStringS();
 
-		return new Model( gl, scene, texture );
+		return new Model( gl, scene );
 	}
 
 	public IReadOnlyList<Mesh> Meshes => _meshes;
@@ -23,12 +23,10 @@ class Model : IModel, IDisposable {
 	readonly Assimp _assimp;
 
 	readonly List<Mesh> _meshes = new();
-	readonly Texture _texture;
 
-	public unsafe Model( GL gl, Scene* scene, Texture texture ) {
+	public unsafe Model( GL gl, Scene* scene ) {
 		_gl = gl;
 		_assimp = Assimp.GetApi();
-		_texture = texture;
 
 		processNode( scene->MRootNode, scene );
 	}
@@ -85,7 +83,7 @@ class Model : IModel, IDisposable {
 				indices.Add( face.MIndices[j] );
 		}
 
-		return new( _gl, buildVertices( vertices ), indices.ToArray(), _texture );
+		return new( _gl, buildVertices( vertices ), indices.ToArray() );
 	}
 
 	float[] buildVertices( List<Vertex> vertexList ) {

--- a/src/Prospect.Engine/Graphics/OpenGL/Texture.cs
+++ b/src/Prospect.Engine/Graphics/OpenGL/Texture.cs
@@ -41,7 +41,7 @@ public sealed class Texture : ITexture, IDisposable {
 		_gl.TexParameter( TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int)GLEnum.Linear );
 		_gl.TexParameter( TextureTarget.Texture2D, TextureParameterName.TextureBaseLevel, 0 );
 		_gl.TexParameter( TextureTarget.Texture2D, TextureParameterName.TextureMaxLevel, 8 );
-
+        
 		//Generating mipmaps.
 		_gl.GenerateMipmap( TextureTarget.Texture2D );
 	}

--- a/src/Prospect.Engine/Graphics/OpenGL/Texture.cs
+++ b/src/Prospect.Engine/Graphics/OpenGL/Texture.cs
@@ -5,55 +5,74 @@ using System.IO;
 
 namespace Prospect.Engine.OpenGL;
 
-public sealed class Texture : ITexture, IDisposable {
-	public static Result<Texture> Load( GL gl, string path ) {
-		if ( !File.Exists( path ) )
-			return Result.Fail();
+public sealed class Texture : ITexture, IDisposable
+{
+    public static Result<Texture> Load( GL gl, string path, TextureFilter filter )
+    {
+        if ( !File.Exists( path ) )
+            return Result.Fail();
 
-		// Load the image from memory.
-		ImageResult result = ImageResult.FromMemory( File.ReadAllBytes( path ), ColorComponents.RedGreenBlueAlpha );
-		
-		return new Texture( gl, result );
-	}
+        // Load the image from memory.
+        var result = ImageResult.FromMemory( File.ReadAllBytes( path ), ColorComponents.RedGreenBlueAlpha );
 
-	readonly uint _handle;
-	readonly GL _gl;
+        return new Texture( gl, result, filter );
+    }
 
-	unsafe Texture( GL gl, ImageResult imageResult ) {
-		_gl = gl;
-		_handle = _gl.GenTexture();
-		Bind();
+    readonly uint _handle;
+    readonly GL _gl;
 
-		fixed ( byte* ptr = imageResult.Data ) {
-			// Create our texture and upload the image data.
-			_gl.TexImage2D( TextureTarget.Texture2D, 0, InternalFormat.Rgba, (uint)imageResult.Width,
-				(uint)imageResult.Height, 0, PixelFormat.Rgba, PixelType.UnsignedByte, ptr );
-		}
+    unsafe Texture( GL gl, ImageResult imageResult, TextureFilter filter )
+    {
+        _gl = gl;
+        _handle = _gl.GenTexture();
+        Bind();
 
-		setParameters();
-	}
+        fixed ( byte* ptr = imageResult.Data )
+        {
+            // Create our texture and upload the image data.
+            _gl.TexImage2D( TextureTarget.Texture2D, 0, InternalFormat.Rgba, (uint)imageResult.Width,
+                (uint)imageResult.Height, 0, PixelFormat.Rgba, PixelType.UnsignedByte, ptr );
+        }
 
-	void setParameters() {
-		//Setting some texture perameters so the texture behaves as expected.
-		_gl.TexParameter( TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (int)GLEnum.ClampToEdge );
-		_gl.TexParameter( TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (int)GLEnum.ClampToEdge );
-		_gl.TexParameter( TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int)GLEnum.LinearMipmapLinear );
-		_gl.TexParameter( TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int)GLEnum.Linear );
-		_gl.TexParameter( TextureTarget.Texture2D, TextureParameterName.TextureBaseLevel, 0 );
-		_gl.TexParameter( TextureTarget.Texture2D, TextureParameterName.TextureMaxLevel, 8 );
-        
-		//Generating mipmaps.
-		_gl.GenerateMipmap( TextureTarget.Texture2D );
-	}
+        setParameters( filter );
+    }
 
-	public void Bind( TextureUnit textureSlot = TextureUnit.Texture0 ) {
-		//When we bind a texture we can choose which textureslot we can bind it to.
-		_gl.ActiveTexture( textureSlot );
-		_gl.BindTexture( TextureTarget.Texture2D, _handle );
-	}
+    void setParameters( TextureFilter filter )
+    {
+        var minFilter = filter switch
+        {
+            TextureFilter.Nearest => GLEnum.NearestMipmapLinear,
+            TextureFilter.Linear or _ => GLEnum.LinearMipmapLinear,
+        };
 
-	public void Dispose() {
-		//In order to dispose we need to delete the opengl handle for the texure.
-		_gl.DeleteTexture( _handle );
-	}
+        var magFilter = filter switch
+        {
+            TextureFilter.Nearest => GLEnum.Nearest,
+            TextureFilter.Linear or _ => GLEnum.Linear,
+        };
+
+        //Setting some texture perameters so the texture behaves as expected.
+        _gl.TexParameter( TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (int)GLEnum.ClampToEdge );
+        _gl.TexParameter( TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (int)GLEnum.ClampToEdge );
+        _gl.TexParameter( TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int)minFilter );
+        _gl.TexParameter( TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int)magFilter );
+        _gl.TexParameter( TextureTarget.Texture2D, TextureParameterName.TextureBaseLevel, 0 );
+        _gl.TexParameter( TextureTarget.Texture2D, TextureParameterName.TextureMaxLevel, 8 );
+
+        //Generating mipmaps.
+        _gl.GenerateMipmap( TextureTarget.Texture2D );
+    }
+
+    public void Bind( TextureUnit textureSlot = TextureUnit.Texture0 )
+    {
+        //When we bind a texture we can choose which textureslot we can bind it to.
+        _gl.ActiveTexture( textureSlot );
+        _gl.BindTexture( TextureTarget.Texture2D, _handle );
+    }
+
+    public void Dispose()
+    {
+        //In order to dispose we need to delete the opengl handle for the texure.
+        _gl.DeleteTexture( _handle );
+    }
 }

--- a/src/Prospect.Engine/Graphics/Texture.cs
+++ b/src/Prospect.Engine/Graphics/Texture.cs
@@ -20,13 +20,17 @@ public sealed class Texture
         var texture = new Texture(res);
 
         if ( Entry.Graphics.HasLoaded )
+        {
             texture.updateFromResource( res );
+            texture._hasLoaded = true;
+        }
 
         _cache[ path ] = texture;
         return texture;
     }
 
     internal ITexture BackendTexture { get; private set; } = null!;
+    internal bool _hasLoaded = false;
     readonly TextureResource _preset;
 
     Texture( TextureResource preset ) => _preset = preset;
@@ -38,5 +42,13 @@ public sealed class Texture
         var texture = Entry.Graphics.LoadTexture( imagePath, res.Filter );
 
         BackendTexture = texture.Value;
+    }
+
+    internal void postBackendLoad()
+    {
+        if ( _hasLoaded ) return;
+        _hasLoaded = true;
+
+        updateFromResource( _preset );
     }
 }

--- a/src/Prospect.Engine/Graphics/Texture.cs
+++ b/src/Prospect.Engine/Graphics/Texture.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Prospect.Engine;
+
+public sealed class Texture
+{
+    internal readonly static Dictionary<string, Texture> _cache = new();
+
+    public static Texture Load(string path)
+    {
+        if ( _cache.TryGetValue( path, out var tex ) )
+            return tex;
+
+        if ( Resources.Get<TextureResource>( path ) is not TextureResource res )
+            // TODO: Make an in-engine error texture and return that instead of throwing
+            throw new Exception( "Texture ain't there pal" );
+
+        var texture = new Texture(res);
+
+        if ( Entry.Graphics.HasLoaded )
+            texture.updateFromResource( res );
+
+        _cache[ path ] = texture;
+        return texture;
+    }
+
+    internal ITexture BackendTexture { get; private set; } = null!;
+    readonly TextureResource _preset;
+
+    Texture( TextureResource preset ) => _preset = preset;
+
+    void updateFromResource(TextureResource res)
+    {
+        var imagePath = Path.Combine( res.Directory, res.ImagePath );
+
+        var texture = Entry.Graphics.LoadTexture( imagePath, res.Filter );
+
+        BackendTexture = texture.Value;
+    }
+}

--- a/src/Prospect.Engine/Graphics/TextureFilter.cs
+++ b/src/Prospect.Engine/Graphics/TextureFilter.cs
@@ -1,0 +1,7 @@
+﻿namespace Prospect.Engine;
+
+public enum TextureFilter
+{
+    Linear,
+    Nearest
+}

--- a/src/Prospect.Engine/Resources/Model.cs
+++ b/src/Prospect.Engine/Resources/Model.cs
@@ -1,6 +1,4 @@
-﻿using YamlDotNet.Serialization;
-
-namespace Prospect.Engine;
+﻿namespace Prospect.Engine;
 
 sealed class ModelResource : Resource {
 	public string MeshPath = "";

--- a/src/Prospect.Engine/Resources/Texture.cs
+++ b/src/Prospect.Engine/Resources/Texture.cs
@@ -1,11 +1,5 @@
 ﻿namespace Prospect.Engine;
 
-enum TextureFilter
-{
-    Linear,
-    Nearest
-}
-
 sealed class TextureResource : Resource
 {
     public string ImagePath = "";

--- a/src/Prospect.Engine/Resources/Texture.cs
+++ b/src/Prospect.Engine/Resources/Texture.cs
@@ -1,0 +1,13 @@
+﻿namespace Prospect.Engine;
+
+enum TextureFilter
+{
+    Linear,
+    Nearest
+}
+
+sealed class TextureResource : Resource
+{
+    public string ImagePath = "";
+    public TextureFilter Filter = TextureFilter.Nearest;
+}

--- a/src/Prospect.TestBed/TestBed.cs
+++ b/src/Prospect.TestBed/TestBed.cs
@@ -71,7 +71,7 @@ public class TestBed : IGame
     {
         var pos = new Vector3( gridPos.X, gridPos.Y, 0f );
         var almostRandom = gridPos.X + gridPos.Y;
-        var transform = new Transform( pos, Rotation.From( new( ( RealTime.Now + almostRandom) * 200f, 0f, 0f ) ) );
+        var transform = new Transform( pos, Rotation.From( new( ( RealTime.Now + almostRandom) * 10f, 0f, 0f ) ) );
         Graphics.DrawModel( _sword, transform );
     }
 


### PR DESCRIPTION
Textures are now their own resource, this makes it possible to specify per-texture properties like their filter type (which is already implemented as an example). Internally textures are also no longer bound to meshes and models, making it more flexible.